### PR TITLE
Fix ogImage path: use absolute URL

### DIFF
--- a/src/content/posts/running-my-own-local-ai-stack.md
+++ b/src/content/posts/running-my-own-local-ai-stack.md
@@ -3,7 +3,7 @@ title: "Twenty years of Linux, and now I run my own AI"
 description: "I've been an open source fan for a long time. Lately that's meant building my own local AI stack so I'm not at the mercy of token bills and shifting licenses."
 pubDatetime: 2026-06-16T09:00:00Z
 tags: ["ai", "local-ai", "open-source", "apple-silicon"]
-ogImage: "/post-images/running-my-own-local-ai-stack/dad-email-cover.png"
+ogImage: "https://kahrens.com/post-images/running-my-own-local-ai-stack/dad-email-cover.png"
 ---
 
 I've been running Linux and Ubuntu for nearly 20 years. I can date it almost exactly, because I still have the email from my Dad back in early 2007 telling me he'd just installed Ubuntu. That's where this started.


### PR DESCRIPTION
## Why

PR #54 deployed and the build failed:

```
[ImageNotFound] Could not load /post-images/running-my-own-local-ai-stack/dad-email-cover.png?astroContentImageFlag
```

The `?astroContentImageFlag` query suffix is the tell: Astro routed the leading-slash path through its image-asset pipeline (which only looks inside `src/`), even though the AstroPaper schema is `image().or(z.string())`. The image() branch errored before the string fallback kicked in.

## Fix

Use a full absolute URL (`https://kahrens.com/post-images/...`). Unambiguously a string, Astro doesn't try to import it.

```diff
- ogImage: "/post-images/running-my-own-local-ai-stack/dad-email-cover.png"
+ ogImage: "https://kahrens.com/post-images/running-my-own-local-ai-stack/dad-email-cover.png"
```

## Verified

`pnpm build` locally — 17 pages built clean, no errors. The cover and the new default-og still ship since they were already committed in PR #54.